### PR TITLE
Add well-defined paths for imports (truffle compatibility)

### DIFF
--- a/src/proxy.sol
+++ b/src/proxy.sol
@@ -47,10 +47,12 @@ contract DSProxy is DSAuth, DSNote {
             target = cache.write(_code);
         }
 
-        response = execute(target, _data);
+        response = execute2(target, _data);
     }
 
-    function execute(address _target, bytes _data)
+    // TODO: bring back to overloaded function? figure out why the heck
+    //  the abi encoder doesn't like this overloading.
+    function execute2(address _target, bytes _data)
         public
         auth
         note

--- a/src/proxy.sol
+++ b/src/proxy.sol
@@ -17,8 +17,8 @@
 
 pragma solidity ^0.4.23;
 
-import "ds-auth/auth.sol";
-import "ds-note/note.sol";
+import "../lib/ds-auth/src/auth.sol";
+import "../lib/ds-note/src/note.sol";
 
 // DSProxy
 // Allows code execution using a persistant identity This can be very


### PR DESCRIPTION
I know this messes up the beautified import statements, but this way I can add ds-proxy as a submodule to a truffle project and everything works swimmingly. It also doesn't appear to mess with `dapp build` or `dapp test`. Example project here: https://github.com/CirclesUBI/circles-contracts/tree/test-circles-person